### PR TITLE
Add GCC hack to suppress unused-parameter warning

### DIFF
--- a/src/api/vfs.cc
+++ b/src/api/vfs.cc
@@ -3,35 +3,36 @@
 // found in the LICENSE file.
 
 #include "berrydb/vfs.h"
+#include "../debug.h"
 
 namespace berrydb {
 
 Vfs::Vfs() noexcept = default;
-Vfs::Vfs(const Vfs& other) noexcept = default;
-Vfs::Vfs(Vfs&& other) noexcept = default;
-Vfs& Vfs::operator =(const Vfs& other) noexcept = default;
-Vfs& Vfs::operator =(Vfs&& other) noexcept = default;
+Vfs::Vfs(const Vfs& other UNUSED) noexcept = default;
+Vfs::Vfs(Vfs&& other UNUSED) noexcept = default;
+Vfs& Vfs::operator =(const Vfs& other UNUSED) noexcept = default;
+Vfs& Vfs::operator =(Vfs&& other UNUSED) noexcept = default;
 
 BlockAccessFile::BlockAccessFile() noexcept = default;
 BlockAccessFile::~BlockAccessFile() = default;
 BlockAccessFile::BlockAccessFile(
-    const BlockAccessFile& other) noexcept = default;
+    const BlockAccessFile& other UNUSED) noexcept = default;
 BlockAccessFile::BlockAccessFile(
-    BlockAccessFile&& other) noexcept = default;
+    BlockAccessFile&& other UNUSED) noexcept = default;
 BlockAccessFile& BlockAccessFile::operator =(
-    const BlockAccessFile& other) noexcept = default;
+    const BlockAccessFile& other UNUSED) noexcept = default;
 BlockAccessFile& BlockAccessFile::operator =(
-    BlockAccessFile&& other) noexcept = default;
+    BlockAccessFile&& other UNUSED) noexcept = default;
 
 RandomAccessFile::RandomAccessFile() noexcept = default;
 RandomAccessFile::~RandomAccessFile() = default;
 RandomAccessFile::RandomAccessFile(
-    const RandomAccessFile& other) noexcept = default;
+    const RandomAccessFile& other UNUSED) noexcept = default;
 RandomAccessFile::RandomAccessFile(
-    RandomAccessFile&& other) noexcept = default;
+    RandomAccessFile&& other UNUSED) noexcept = default;
 RandomAccessFile& RandomAccessFile::operator =(
-    const RandomAccessFile& other) noexcept = default;
+    const RandomAccessFile& other UNUSED) noexcept = default;
 RandomAccessFile& RandomAccessFile::operator =(
-    RandomAccessFile&& other) noexcept = default;
+    RandomAccessFile&& other UNUSED) noexcept = default;
 
 }  // namespace berrydb

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,19 @@
+
+#ifndef BERRYDB_DEBUG_H_
+#define BERRYDB_DEBUG_H_
+
+#if defined(_MSC_VER)
+
+#define UNUSED 
+#define NO_RETURN
+#define NO_INLINE
+
+#elif defined(__clang__) || defined(__GNUC__)
+
+#define UNUSED __attribute__((unused))
+#define NO_RETURN __attribute__((noreturn))
+#define NO_INLINE __attribute__((noinline))
+
+#endif  // _MSC_VER
+
+#endif  // BERRYDB_DEBUG_H_


### PR DESCRIPTION
```
FAILED: CMakeFiles/berrydb.dir/src/api/vfs.cc.o 
/usr/bin/c++   -DGOOGLE_GLOG_DLL_DECL="" -I../include -I../platform -Iplatform -Ithird_party/glog -I../third_party/glog/src -Wall -Wextra -Werror -fno-exceptions -fno-rtti   -std=c++14 -MMD -MT CMakeFiles/berrydb.dir/src/api/vfs.cc.o -MF CMakeFiles/berrydb.dir/src/api/vfs.cc.o.d -o CMakeFiles/berrydb.dir/src/api/vfs.cc.o -c ../src/api/vfs.cc
../src/api/vfs.cc:10:21: error: unused parameter ‘other’ [-Werror=unused-parameter]
 Vfs::Vfs(const Vfs& other) noexcept = default;
                     ^
../src/api/vfs.cc:10:39: note: synthesized method ‘berrydb::Vfs::Vfs(const berrydb::Vfs&)’ first required here 
 Vfs::Vfs(const Vfs& other) noexcept = default;
                                       ^
../src/api/vfs.cc:11:16: error: unused parameter ‘other’ [-Werror=unused-parameter]
 Vfs::Vfs(Vfs&& other) noexcept = default;
                ^
../src/api/vfs.cc:11:34: note: synthesized method ‘berrydb::Vfs::Vfs(berrydb::Vfs&&)’ first required here 
 Vfs::Vfs(Vfs&& other) noexcept = default;
                                  ^
../src/api/vfs.cc:18:28: error: unused parameter ‘other’ [-Werror=unused-parameter]
     const BlockAccessFile& other) noexcept = default;
                            ^
../src/api/vfs.cc:18:46: note: synthesized method ‘berrydb::BlockAccessFile::BlockAccessFile(const berrydb::BlockAccessFile&)’ first required here 
     const BlockAccessFile& other) noexcept = default;
                                              ^
../src/api/vfs.cc:20:23: error: unused parameter ‘other’ [-Werror=unused-parameter]
     BlockAccessFile&& other) noexcept = default;
                       ^
../src/api/vfs.cc:20:41: note: synthesized method ‘berrydb::BlockAccessFile::BlockAccessFile(berrydb::BlockAccessFile&&)’ first required here 
     BlockAccessFile&& other) noexcept = default;
                                         ^
../src/api/vfs.cc:29:29: error: unused parameter ‘other’ [-Werror=unused-parameter]
     const RandomAccessFile& other) noexcept = default;
                             ^
../src/api/vfs.cc:29:47: note: synthesized method ‘berrydb::RandomAccessFile::RandomAccessFile(const berrydb::RandomAccessFile&)’ first required here 
     const RandomAccessFile& other) noexcept = default;
                                               ^
../src/api/vfs.cc:31:24: error: unused parameter ‘other’ [-Werror=unused-parameter]
     RandomAccessFile&& other) noexcept = default;
                        ^
../src/api/vfs.cc:31:42: note: synthesized method ‘berrydb::RandomAccessFile::RandomAccessFile(berrydb::RandomAccessFile&&)’ first required here 
     RandomAccessFile&& other) noexcept = default;
                                          ^
cc1plus: all warnings being treated as errors
[35/96] Building CXX object third_party/googletest/googlemock/gtest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
ninja: build stopped: subcommand failed.
```
Failed during building.